### PR TITLE
Fix run_training_session argument mismatch

### DIFF
--- a/main.py
+++ b/main.py
@@ -150,7 +150,6 @@ def main():
             is_sampled,
             device,
             args,
-            getattr(args, 'accum_steps', 1),
         )
 
         # --- Cleanup ---


### PR DESCRIPTION
## Summary
- remove nonexistent `accum_steps` argument from training call

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_687352e3a47c832382f993e9c3d618bd